### PR TITLE
Hide the `__call__` traceback in pytest failures.

### DIFF
--- a/pytest_helpers_namespace/plugin.py
+++ b/pytest_helpers_namespace/plugin.py
@@ -39,6 +39,7 @@ class FuncWrapper(object):
         '''
         This wrapper will just call the actual helper function
         '''
+        __tracebackhide__ = True
         return self.func(*args, **kwargs)
 
 


### PR DESCRIPTION
As proposed in Issue #2, hides the extra layer in the traceback due to the `__call__` wrapper.
